### PR TITLE
Reverted vagrantfile to use default box

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,8 +5,12 @@ VAGRANTFILE_API_VERSION = "2"
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   # Every Vagrant virtual environment requires a box to build off of.
-  #config.vm.box = "ubuntu/trusty64"
-	config.vm.box = "hashicorp/precise32"
+  config.vm.box = "precise64"
+
+  
+  # The url from where the 'config.vm.box' box will be fetched if it
+  # doesn't already exist on the user's system.
+  config.vm.box_url = "http://files.vagrantup.com/precise64.box"
 
   # Share an additional folder to the guest VM. The first argument is
   # the path on the host to the actual folder. The second argument is

--- a/setup.sh
+++ b/setup.sh
@@ -12,7 +12,7 @@ apt-get install -y php5 libapache2-mod-php5
 
 if ! [ -L /var/www ]; then
 	rm -rf /var/www
-	ln -fs /vagrant/public /var/www
+	ln -fs /vagrant/public/html /var/www
 fi
 
 /etc/init.d/apache2 restart


### PR DESCRIPTION
Trusty64 wasn't working on windows 7 machines. Reverted to the default
precise64 used in the default vagrantfile.
